### PR TITLE
Support for SOURCES_AUTO and DOCS_AUTO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
-        classpath("com.otaliastudios.tools:publisher:0.1.4")
+        // classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
+        classpath("com.otaliastudios.tools:publisher:0.1.5")
     }
 }
 

--- a/publisher/build.gradle.kts
+++ b/publisher/build.gradle.kts
@@ -2,51 +2,38 @@
  * Copyright (c) 2020 Otalia Studios. Author: Mattia Iavarone.
  */
 
+import com.otaliastudios.tools.publisher.PublisherExtension
+
 plugins {
     `kotlin-dsl`
 
     // To publish the plugin itself...
-    id("org.jetbrains.dokka")
     id("maven-publisher-bintray")
 }
 
 dependencies {
-    api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    /* Depend on the android gradle plugin, since we want to access it in our plugin */
-    api("com.android.tools.build:gradle:3.6.1")
-    /* Depend on the kotlin plugin, since we want to access it in our plugin */
-    api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-    /* Depend on the default Gradle API's since we want to build a custom plugin */
-    api(gradleApi())
-    api(gradleKotlinDsl())
-    api(localGroovy())
+    api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4") // bintray
+    api("com.android.tools.build:gradle:3.6.1") // android gradle plugin
+    api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61") // kotlin gradle plugin
+    api("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1") // dokka for auto docs
+    api(gradleApi()) // gradle
+    api(gradleKotlinDsl()) // not sure if needed
+    api(localGroovy()) // groovy
 }
 
 // To publish the plugin itself...
-
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource)
-}
-
-val dokkaJar by tasks.registering(Jar::class) {
-    val dokka = tasks["dokka"] as org.jetbrains.dokka.gradle.DokkaTask
-    dependsOn(dokka)
-    archiveClassifier.set("javadoc")
-    from(dokka.outputDirectory)
-}
 
 publisher {
     auth.user = "BINTRAY_USER"
     auth.key = "BINTRAY_KEY"
     auth.repo = "BINTRAY_REPO"
     project.artifact = "publisher"
-    project.description = "A lightweight, handly tool for publishing maven packages to different kinds of repositories"
+    project.description = "A lightweight, handy tool for publishing maven packages to different kinds of repositories"
     project.group = "com.otaliastudios.tools"
     project.url = "https://github.com/natario1/MavenPublisher"
     project.vcsUrl = "https://github.com/natario1/MavenPublisher.git"
-    project.addLicense(com.otaliastudios.tools.publisher.PublisherExtension.License.APACHE_2_0)
-    release.version = "0.1.4"
-    release.setSources(sourcesJar.get())
-    release.setDocs(dokkaJar.get())
+    project.addLicense(PublisherExtension.License.APACHE_2_0)
+    release.version = "0.1.5"
+    release.setSources(PublisherExtension.Release.SOURCES_AUTO)
+    release.setDocs(PublisherExtension.Release.DOCS_AUTO)
 }

--- a/publisher/src/main/kotlin/PublisherExtension.kt
+++ b/publisher/src/main/kotlin/PublisherExtension.kt
@@ -61,6 +61,21 @@ abstract class PublisherExtension {
         fun setDocs(docsJar: Jar) {
             docs = docsJar
         }
+
+        fun setSources(sourcesProvider: Any) {
+            sources = sourcesProvider
+        }
+
+        fun setDocs(docsProvider: Any) {
+            docs = docsProvider
+        }
+
+        companion object {
+            @JvmField
+            val SOURCES_AUTO = Any()
+            @JvmField
+            val DOCS_AUTO = Any()
+        }
     }
     open val release: Release = Release()
 

--- a/publisher/src/main/kotlin/PublisherPlugin.kt
+++ b/publisher/src/main/kotlin/PublisherPlugin.kt
@@ -1,8 +1,8 @@
 package com.otaliastudios.tools.publisher
 
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.AndroidBasePlugin
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
@@ -74,7 +74,7 @@ abstract class PublisherPlugin<M : PublisherExtension>(
         }
         model.release.version = model.release.version ?:
             if (target.isAndroid) {
-                val android = target.extensions.getByName("android") as BaseAppModuleExtension
+                val android = target.extensions.getByName("android") as BaseExtension
                 android.defaultConfig.versionName + android.defaultConfig.versionNameSuffix
             } else {
                 target.version.toString()
@@ -175,7 +175,7 @@ abstract class PublisherPlugin<M : PublisherExtension>(
         return target.tasks.create("autoSourcesTask", Jar::class.java) {
             archiveClassifier.set("sources")
             if (target.isAndroid) {
-                val android = target.extensions.getByName("android") as BaseAppModuleExtension
+                val android = target.extensions.getByName("android") as BaseExtension
                 from(android.sourceSets["main"].java.srcDirs)
             } else {
                 val sourceSets = target.extensions.getByName("sourceSets") as SourceSetContainer

--- a/publisher/src/main/kotlin/PublisherPlugin.kt
+++ b/publisher/src/main/kotlin/PublisherPlugin.kt
@@ -2,6 +2,7 @@ package com.otaliastudios.tools.publisher
 
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.AndroidBasePlugin
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
@@ -9,11 +10,17 @@ import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
+import org.jetbrains.dokka.gradle.DokkaPlugin
+import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
 import java.io.FileInputStream
-import java.lang.IllegalArgumentException
 import java.util.*
+import kotlin.IllegalArgumentException
 import kotlin.reflect.KClass
 
 abstract class PublisherPlugin<M : PublisherExtension>(
@@ -65,11 +72,28 @@ abstract class PublisherPlugin<M : PublisherExtension>(
         if (model.project.packaging == null && target.isAndroidLibrary) {
             model.project.packaging = "aar"
         }
-
-        model.release.version = model.release.version ?: target.version.toString()
+        model.release.version = model.release.version ?:
+            if (target.isAndroid) {
+                val android = target.extensions.getByName("android") as BaseAppModuleExtension
+                android.defaultConfig.versionName + android.defaultConfig.versionNameSuffix
+            } else {
+                target.version.toString()
+            }
         model.release.vcsTag = model.release.vcsTag ?: "v${model.release.version!!}"
         model.release.description = model.release.description ?:
                 "${model.project.name!!} ${model.release.vcsTag!!}"
+
+        // Auto-sources and auto-docs support
+        if (model.release.sources == PublisherExtension.Release.SOURCES_AUTO) {
+            model.release.setSources(createSourcesJar(target))
+        }
+        if (model.release.docs == PublisherExtension.Release.DOCS_AUTO) {
+            model.release.setDocs(if (target.isKotlin) {
+                createDocsKotlinJar(target)
+            } else {
+                createDocsJavaJar(target)
+            })
+        }
     }
 
     protected open fun checkModel(target: Project, model: M) {
@@ -146,8 +170,35 @@ abstract class PublisherPlugin<M : PublisherExtension>(
         // We failed. Return null.
         return null
     }
+
+    private fun createSourcesJar(target: Project): Jar {
+        return target.tasks.create("autoSourcesTask", Jar::class.java) {
+            archiveClassifier.set("sources")
+            if (target.isAndroid) {
+                val android = target.extensions.getByName("android") as BaseAppModuleExtension
+                from(android.sourceSets["main"].java.srcDirs)
+            } else {
+                val sourceSets = target.extensions.getByName("sourceSets") as SourceSetContainer
+                from(sourceSets["main"].allSource)
+            }
+        }
+    }
+
+    private fun createDocsKotlinJar(target: Project): Jar {
+        target.apply<DokkaPlugin>()
+        return target.tasks.create("autoDocsTask", Jar::class.java) {
+            val task = target.tasks["dokka"]
+            dependsOn(task)
+            archiveClassifier.set("javadoc")
+            from((task as DokkaTask).outputDirectory)
+        }
+    }
+
+    private fun createDocsJavaJar(target: Project): Jar {
+        throw IllegalArgumentException("Release.DOCS_AUTO only works in kotlin projects.")
+    }
 }
 
-
+val Project.isKotlin get() = plugins.toList().any { it is KotlinBasePluginWrapper }
 val Project.isAndroid get() = plugins.toList().any { it is AndroidBasePlugin }
 val Project.isAndroidLibrary get() = plugins.toList().any { it is LibraryPlugin }


### PR DESCRIPTION
Adds 
- `release.setSources(SOURCES_AUTO)`
- `release.setDocs(DOCS_AUTO)` (Kotlin only)

to create (opinionated, but automatic) sources and docs Jars. 

Release version on android will now fallback to `android.defaultConfig.version` .
